### PR TITLE
Package product installable on macOS 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: make build
+
+  test:
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test
+      run: make test
+
+  install:
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install
+      run: make install
+    - name: Uninstall
+      run: make uninstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ '*' ]
+    pull_request: [ main ]
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,37 @@
+SHELL = /bin/bash
+
+prefix ?= /usr/local
+bindir ?= $(prefix)/bin
+libdir ?= $(prefix)/lib
+srcdir = Sources
+
+REPODIR = $(shell pwd)
+BUILDDIR = $(REPODIR)/.build
+SOURCES = $(wildcard $(srcdir)/**/*.swift)
+
+.DEFAULT_GOAL = all
+
 build:
 	swift build -c release
 
 test:
 	swift test
 
-install: build
-	install "$(shell swift build -c release --show-bin-path)/swift-release-notes" /usr/local/bin/
+swift-release-notes: $(SOURCES)
+	@swift build \
+		-c release \
+		--disable-sandbox \
+		--build-path "$(BUILDDIR)"
+
+.PHONY: install
+install: swift-release-notes
+	@install -d "$(bindir)"
+	@install "$(wildcard $(BUILDDIR)/**/release/swift-release-notes)" "$(bindir)"
+
+.PHONY: uninstall
+uninstall:
+	@rm -rf "$(bindir)/swift-release-notes"
+
+.PHONY: clean
+distclean:
+	@rm -f $(BUILDDIR)/release

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,10 @@ import PackageDescription
 let package = Package(
     name: "swift-release-notes",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v11),
+    ],
+    products: [
+        .executable(name: "swift-release-notes", targets: ["swift-release-notes"]),
     ],
     dependencies: [
         .package(name: "SemanticVersion",
@@ -16,22 +19,25 @@ let package = Package(
                  url: "https://github.com/apple/swift-argument-parser",
                  from: "1.0.0"),
         .package(name: "swift-parsing",
-                 url: "https://github.com/pointfreeco/swift-parsing", 
-                 from: "0.4.1")
+                 url: "https://github.com/pointfreeco/swift-parsing",
+                 from: "0.4.1"),
     ],
     targets: [
         .executableTarget(
             name: "swift-release-notes",
-            dependencies: ["ReleaseNotesCore"]),
+            dependencies: ["ReleaseNotesCore"]
+        ),
         .target(
             name: "ReleaseNotesCore",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Parsing", package: "swift-parsing"),
-                "SemanticVersion"
-            ]),
+                "SemanticVersion",
+            ]
+        ),
         .testTarget(
             name: "ReleaseNotesCoreTests",
-            dependencies: ["ReleaseNotesCore"]),
+            dependencies: ["ReleaseNotesCore"]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -24,9 +24,23 @@ https://github.com/apple/swift-driver/releases (main)
 https://github.com/apple/swift-nio/releases (2.36.0)
 ```
 
-##
+## Installation
+### Using [Mint](https://github.com/yonaskolb/mint)
 
-To install:
+```
+$ mint install SwiftPackageIndex/ReleaseNotes
+```
 
-- clone this repository
-- run `make install` to build and install the executable in `/usr/local/bin`
+### Installing from source
+
+You can also build and install from source by cloning this project and running
+`make install` (macOS 11 or later).
+
+Manually
+Run the following commands to build and install manually:
+
+```
+$ git clone https://github.com/SwiftPackageIndex/ReleaseNotes.git
+$ cd ReleaseNotes
+$ make install
+```

--- a/Sources/ReleaseNotesCore/ParsableCommand+async.swift
+++ b/Sources/ReleaseNotesCore/ParsableCommand+async.swift
@@ -2,18 +2,16 @@
 
 import ArgumentParser
 
-
-@available(macOS 12.0, *)
+@available(macOS 11.0, *)
 protocol AsyncParsableCommand: ParsableCommand {
     mutating func runAsync() async throws
 }
-
 
 extension ParsableCommand {
     static func main(_ arguments: [String]? = nil) async {
         do {
             var command = try parseAsRoot(arguments)
-            if #available(macOS 12.0, *), var asyncCommand = command as? AsyncParsableCommand {
+            if #available(macOS 11.0, *), var asyncCommand = command as? AsyncParsableCommand {
                 try await asyncCommand.runAsync()
             } else {
                 try command.run()


### PR DESCRIPTION
I reduced minimum platform version to macOS 11 as Xcode 13.2 brings concurrency support for < macOS 12. Theoretically this can be lowered further.

Added a package product to allow installation with package manager Mint. Otherwise error message `Executable product not found`

Added GitHub workflow to verify build/test/install through Makefile commands. GitHub workflow needs to use Xcode 13.2 explicitly as the current default is Xcode 13.1. Otherwise error message `error: concurrency is only available in macOS 12.0.0 or newer`