### PR TITLE
Parse new package updates

### DIFF
--- a/Sources/ReleaseNotesCore/ReleaseNotes.swift
+++ b/Sources/ReleaseNotesCore/ReleaseNotes.swift
@@ -50,7 +50,7 @@ struct ReleaseNotes: AsyncParsableCommand {
         for update in updates {
             let releasesURL = packageMap[update.packageName]
                 .map { $0.absoluteString.droppingGitExtension + "/releases" }
-            ?? "could not construct releases URL"
+            ?? "\(update.packageName)"
             print(releasesURL, "(\(update.oldRevision?.description ?? "new package"))")
         }
     }

--- a/Sources/ReleaseNotesCore/ReleaseNotes.swift
+++ b/Sources/ReleaseNotesCore/ReleaseNotes.swift
@@ -51,7 +51,7 @@ struct ReleaseNotes: AsyncParsableCommand {
             let releasesURL = packageMap[update.packageName]
                 .map { $0.absoluteString.droppingGitExtension + "/releases" }
             ?? "could not construct releases URL"
-            print(releasesURL, "(\(update.oldRevision))")
+            print(releasesURL, "(\(update.oldRevision?.description ?? "new package"))")
         }
     }
 

--- a/Sources/ReleaseNotesCore/Update.swift
+++ b/Sources/ReleaseNotesCore/Update.swift
@@ -14,9 +14,13 @@
 
 struct Update: CustomStringConvertible, Equatable {
     var packageName: PackageName
-    var oldRevision: Revision
+    var oldRevision: Revision?
 
     var description: String {
-        "\(packageName) @ \(oldRevision)"
+        if let oldRevision = oldRevision {
+            return "\(packageName) @ \(oldRevision)"
+        } else {
+            return "\(packageName) (new package)"
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1535

```
6 dependencies have changed:
~ swift-tools-support-core main -> swift-tools-support-core Revision(identifier: "d318eaafe60f20be0f0bbc658793f64bf83847d8") main
+ swift-collections 1.0.2
~ fluent-postgres-driver 2.2.2 -> fluent-postgres-driver 2.2.3
~ swift-driver main -> swift-driver Revision(identifier: "a034b0bc0cc1366e289e25e00b3e0b21089c98fe") main
~ swift-argument-parser 1.0.2 -> swift-argument-parser 1.0.3
~ SwiftPM main -> SwiftPM Revision(identifier: "658654765f5a7dfb3456c37dafd3ed8cd8b363b4") main
Failed to parse results from package update.

Please file an issue with the the output above.
```