### PR TITLE
update to new swift-parsing API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-parsing",
         "state": {
           "branch": null,
-          "revision": "b91a41bb54660cafbcd2d1b19328b9d86f92c80e",
-          "version": "0.4.1"
+          "revision": "1d3aa2f359388b67c16000556830645382cd5c4f",
+          "version": "0.8.0"
         }
       }
     ]

--- a/Sources/ReleaseNotesCore/ReleaseNotes.swift
+++ b/Sources/ReleaseNotesCore/ReleaseNotes.swift
@@ -35,10 +35,13 @@ struct ReleaseNotes: AsyncParsableCommand {
             return
         }
 
-        guard let updates = Parser.packageUpdate.parse(output) else {
+        let updates: [Update]
+        do {
+            updates = try Parser.packageUpdate.parse(output)
+        } catch {
             print("Failed to parse results from package update.\n")
             print("Please file an issue with the the output above.")
-            return
+            throw error
         }
 
         guard !updates.isEmpty else {

--- a/Tests/ReleaseNotesTests/ParserCoreTests.swift
+++ b/Tests/ReleaseNotesTests/ParserCoreTests.swift
@@ -22,33 +22,27 @@ final class ParserCoreTests: XCTestCase {
     func test_progressLine() throws {
         do {
             var input = "Updating https://github.com/pointfreeco/swift-parsing\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
         do {
             var input = "Updated https://github.com/apple/swift-argument-parser (0.81s)\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
         do {
             var input = "Computing version for https://github.com/pointfreeco/swift-parsing\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
         do {
             var input = "Computed https://github.com/pointfreeco/swift-parsing at 0.4.1 (0.02s)\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
         do {
             var input = "Creating working copy for https://github.com/JohnSundell/Plot.git\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
         do {
             var input = "Working copy of https://github.com/JohnSundell/Plot.git resolved at 0.10.0\n"[...]
-            XCTAssertNotNil(Parser.progressLine.parse(&input))
-            XCTAssertEqual(input, "")
+            try Parser.progressLine.parse(&input)
         }
     }
 
@@ -70,83 +64,62 @@ final class ParserCoreTests: XCTestCase {
             Working copy of https://github.com/JohnSundell/Plot.git resolved at 0.10.0
 
             """[...]
-        XCTAssertNotNil(Skip(Parser.progress).parse(&input))
-        XCTAssertEqual(input, "")
+        try Skip { Parser.progress }.parse(&input)
     }
 
     func test_dependencyCount() throws {
         do {
             var input = "1 dependency has changed:"[...]
-            XCTAssertEqual(Parser.dependencyCount.parse(&input), 1)
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.dependencyCount.parse(&input), 1)
         }
         do {
             var input = "12 dependencies have changed:"[...]
-            XCTAssertEqual(Parser.dependencyCount.parse(&input), 12)
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.dependencyCount.parse(&input), 12)
         }
         do {
             var input = "0 dependencies have changed."[...]
-            XCTAssertEqual(Parser.dependencyCount.parse(&input), 0)
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.dependencyCount.parse(&input), 0)
         }
     }
 
     func test_upToStart() throws {
         do {
             var input = "~ foo"[...]
-            XCTAssertNotNil(Parser.upToStart.parse(&input))
+            XCTAssertNotNil(try? Parser.upToStart.parse(&input))
             XCTAssertEqual(input, "~ foo")
         }
         do {
             var input = "+ foo"[...]
-            XCTAssertNotNil(Parser.upToStart.parse(&input))
+            XCTAssertNotNil(try? Parser.upToStart.parse(&input))
             XCTAssertEqual(input, "+ foo")
         }
         do {
-            var input = "other"[...]
-            XCTAssertNotNil(Parser.upToStart.parse(&input))
-            XCTAssertEqual(input, "")
+            XCTAssertNotNil(try Parser.upToStart.parse("other"))
         }
     }
 
     func test_semanticVersion() throws {
         do {
-            var input = "1.2.3"[...]
-            XCTAssertEqual(Parser.semanticVersion.parse(&input),
-                           .tag(.init(1, 2, 3)))
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.semanticVersion.parse("1.2.3"), .tag(.init(1, 2, 3)))
         }
         do {
-            var input = "1.2.3-b1"[...]
-            XCTAssertEqual(Parser.semanticVersion.parse(&input),
-                           .tag(.init("1.2.3-b1")!))
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try? Parser.semanticVersion.parse("1.2.3-b1"), .tag(.init("1.2.3-b1")!))
         }
     }
 
     func test_revision() throws {
         do {
-            var input = "1.2.3"[...]
-            XCTAssertEqual(Parser.revision.parse(&input), .tag(.init(1, 2, 3)))
-            XCTAssertEqual(input, "")
-        }
-        do {
-            var input = "main"[...]
-            XCTAssertEqual(Parser.revision.parse(&input), .branch("main"))
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.revision.parse("main"), .branch("main"))
         }
     }
 
     func test_newPackage() throws {
         do {
-            var input = "+ swift-collections 1.0.2"[...]
-            XCTAssertEqual(Parser.newPackage.parse(&input), .init(packageName: "swift-collections"))
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.newPackage.parse("+ swift-collections 1.0.2"), .init(packageName: "swift-collections"))
         }
         do {
             var input = "~ swift-collections 1.0.2"[...]
-            XCTAssertNil(Parser.newPackage.parse(&input))
+            XCTAssertNil(try? Parser.newPackage.parse(&input))
             XCTAssertEqual(input, "~ swift-collections 1.0.2")
         }
     }
@@ -154,68 +127,52 @@ final class ParserCoreTests: XCTestCase {
     func test_update() throws {
         do {
             var input = #"~ swift-tools-support-core main -> swift-tools-support-core Revision(identifier: "4afd18e40eb028cd9fbe7342e3f98020ea9fdf1a") main"#[...]
-            XCTAssertEqual(Parser.update.parse(&input),
+            XCTAssertEqual(try Parser.update.parse(&input),
                            .init(packageName: "swift-tools-support-core",
                                  oldRevision: .branch("main")))
-            XCTAssertEqual(input, "")
         }
         do {
-            var input = #"~ vapor 4.54.0 -> vapor 4.54.1"#[...]
-            XCTAssertEqual(Parser.update.parse(&input),
-                           .init(packageName: "vapor",
-                                 oldRevision: .tag(.init(4, 54, 0))))
-            XCTAssertEqual(input, "")
+            XCTAssertEqual(try Parser.update.parse(#"~ vapor 4.54.0 -> vapor 4.54.1"#),
+                           .init(packageName: "vapor", oldRevision: .tag(.init(4, 54, 0))))
         }
         do {
-            var input = "+ swift-collections 1.0.2"[...]
-            XCTAssertEqual(Parser.update.parse(&input),
+            XCTAssertEqual(try Parser.update.parse("+ swift-collections 1.0.2"),
                            .init(packageName: "swift-collections"))
-            XCTAssertEqual(input, "")
         }
     }
 
     func test_updates() throws {
         do {
-            var input = #"~ vapor 4.54.0 -> vapor 4.54.1"#[...]
-            XCTAssertEqual(Parser.updates.parse(&input),
+            XCTAssertEqual(try Parser.updates.parse(#"~ vapor 4.54.0 -> vapor 4.54.1"#),
                            [.init(packageName: "vapor",
                                  oldRevision: .tag(.init(4, 54, 0)))])
-            XCTAssertEqual(input, "")
         }
         do {
-            var input = "+ swift-collections 1.0.2"[...]
-            XCTAssertEqual(Parser.updates.parse(&input),
+            XCTAssertEqual(try Parser.updates.parse("+ swift-collections 1.0.2"),
                            [.init(packageName: "swift-collections")])
-            XCTAssertEqual(input, "")
         }
         do {
-            var input = """
-            ~ vapor 4.54.0 -> vapor 4.54.1
-            + swift-collections 1.0.2
-            """[...]
-
-            XCTAssertEqual(Parser.updates.parse(&input),
+            XCTAssertEqual(try Parser.updates.parse("""
+                            ~ vapor 4.54.0 -> vapor 4.54.1
+                            + swift-collections 1.0.2
+                            """),
                            [.init(packageName: "vapor",
                                   oldRevision: .tag(.init(4, 54, 0))),
                             .init(packageName: "swift-collections")])
-            XCTAssertEqual(input, "")
         }
         do {
-            var input = """
-            + swift-collections 1.0.2
-            ~ vapor 4.54.0 -> vapor 4.54.1
-            """[...]
-
-            XCTAssertEqual(Parser.updates.parse(&input),
+            XCTAssertEqual(try Parser.updates.parse("""
+                            + swift-collections 1.0.2
+                            ~ vapor 4.54.0 -> vapor 4.54.1
+                            """),
                            [.init(packageName: "swift-collections"),
                             .init(packageName: "vapor",
                                   oldRevision: .tag(.init(4, 54, 0)))])
-            XCTAssertEqual(input, "")
         }
     }
 
     func test_updates_full_list() throws {
-        var input = """
+        XCTAssertEqual(try Parser.updates.parse("""
             + swift-collections 1.0.2
             ~ swift-tools-support-core main -> swift-tools-support-core Revision(identifier: "4afd18e40eb028cd9fbe7342e3f98020ea9fdf1a") main
             ~ vapor 4.54.0 -> vapor 4.54.1
@@ -227,8 +184,7 @@ final class ParserCoreTests: XCTestCase {
             ~ SwiftPM main -> SwiftPM Revision(identifier: "49ba6e97a60d1ea4f89c43503c7533e02c6d6913") main
             ~ swift-nio 2.36.0 -> swift-nio 2.37.0
             ~ llbuild main -> llbuild Revision(identifier: "db8311d7d284cae487dff582de980db5a918692f") main
-            """[...]
-        XCTAssertEqual(Parser.updates.parse(&input), [
+            """), [
             .init(packageName: "swift-collections"),
             .init(packageName: "swift-tools-support-core", oldRevision: .branch("main")),
             .init(packageName: "vapor", oldRevision: .tag(.init(4, 54, 0))),
@@ -241,12 +197,12 @@ final class ParserCoreTests: XCTestCase {
             .init(packageName: "swift-nio", oldRevision: .tag(.init(2, 36, 0))),
             .init(packageName: "llbuild", oldRevision: .branch("main")),
         ])
-        XCTAssertEqual(input, "")
     }
 
     func test_packageUpdate() throws {
         do {
-            var input = """
+            XCTAssertEqual(try Parser.packageUpdate.parse(
+            """
             10 dependencies have changed:
             ~ swift-tools-support-core main -> swift-tools-support-core Revision(identifier: "4afd18e40eb028cd9fbe7342e3f98020ea9fdf1a") main
             ~ vapor 4.54.0 -> vapor 4.54.1
@@ -258,18 +214,20 @@ final class ParserCoreTests: XCTestCase {
             ~ SwiftPM main -> SwiftPM Revision(identifier: "49ba6e97a60d1ea4f89c43503c7533e02c6d6913") main
             ~ swift-nio 2.36.0 -> swift-nio 2.37.0
             ~ llbuild main -> llbuild Revision(identifier: "db8311d7d284cae487dff582de980db5a918692f") main
-            """[...]
-            XCTAssertEqual(Parser.packageUpdate.parse(&input)?.count, 10)
+            """
+            ).count, 10)
         }
         do {
-            var input = """
+            XCTAssertEqual(try Parser.packageUpdate.parse(
+            """
 
             0 dependencies have changed.
-            """[...]
-            XCTAssertEqual(Parser.packageUpdate.parse(&input)?.count, 0)
+            """
+            ).count, 0)
         }
         do {
-            var input = """
+            XCTAssertEqual(try Parser.packageUpdate.parse(
+            """
             Updating https://github.com/pointfreeco/swift-parsing
             Updating https://github.com/apple/swift-argument-parser
             Updating https://github.com/SwiftPackageIndex/SemanticVersion
@@ -284,13 +242,14 @@ final class ParserCoreTests: XCTestCase {
             Computed https://github.com/apple/swift-argument-parser at 1.0.2 (0.01s)
 
             0 dependencies have changed.
-            """[...]
-            XCTAssertEqual(Parser.packageUpdate.parse(&input)?.count, 0)
+            """
+            ).count, 0)
         }
     }
 
     func test_regression_new_package() throws {
-        var input = """
+        XCTAssertEqual(try Parser.packageUpdate.parse(
+        """
         6 dependencies have changed:
         + swift-collections 1.0.2
         ~ fluent-postgres-driver 2.2.2 -> fluent-postgres-driver 2.2.3
@@ -298,20 +257,33 @@ final class ParserCoreTests: XCTestCase {
         ~ swift-tools-support-core main -> swift-tools-support-core Revision(identifier: "d318eaafe60f20be0f0bbc658793f64bf83847d8") main
         ~ swift-argument-parser 1.0.2 -> swift-argument-parser 1.0.3
         ~ SwiftPM main -> SwiftPM Revision(identifier: "658654765f5a7dfb3456c37dafd3ed8cd8b363b4") main
-        """[...]
-        XCTAssertEqual(Parser.packageUpdate.parse(&input)?.count, 6)
+        """
+        ).count, 6)
     }
 
     func test_progress_resilience() throws {
         // Ensure random output before the dependency count line is ignored
-        var input = """
-            foo
-            bar
-            ~ something
-            1 dependency has changed:
-            ~ fluent-postgres-driver 2.2.2 -> fluent-postgres-driver 2.2.3
-            """[...]
-        XCTAssertEqual(Parser.packageUpdate.parse(&input)?.count, 1)
+        XCTAssertEqual(try Parser.packageUpdate.parse(
+        """
+        foo
+        bar
+        ~ something
+        1 dependency has changed:
+        ~ fluent-postgres-driver 2.2.2 -> fluent-postgres-driver 2.2.3
+
+        """
+        ).count, 1)
     }
 
+    func test_additional_newlines_at_end() throws {
+        // Ensure random output before the dependency count line is ignored
+        XCTAssertEqual(try Parser.packageUpdate.parse(
+        """
+        1 dependency has changed:
+        ~ fluent-postgres-driver 2.2.2 -> fluent-postgres-driver 2.2.3
+
+
+        """
+        ).count, 1)
+    }
 }


### PR DESCRIPTION
* bumps swift-parsing to 0.8.0
* adjusts to new APIs
* makes use of new, all consuming `parse(s: String)` API to cleanup tests
* uses new API to drop having to check for empty strings at the end